### PR TITLE
Sign of fate #164

### DIFF
--- a/app/src/main/java/com/doomhamsters/cards/CardCommandId.kt
+++ b/app/src/main/java/com/doomhamsters/cards/CardCommandId.kt
@@ -4,6 +4,7 @@ package com.doomhamsters.cards
 /** Lists the supported activatable card command identifiers. */
 enum class CardCommandId {
     POWER_NAP,
+    SIGN_OF_FATE,
     QUICK_PEEK;
 
     companion object {

--- a/app/src/main/java/com/doomhamsters/cards/CardRegistry.kt
+++ b/app/src/main/java/com/doomhamsters/cards/CardRegistry.kt
@@ -9,12 +9,12 @@ import com.doomhamsters.cards.definitions.NormalCardDefinition
 import com.doomhamsters.cards.definitions.HyperModeCardDefinition
 import com.doomhamsters.cards.definitions.PowerNapCardDefinition
 import com.doomhamsters.cards.definitions.QuickPeekCardDefinition
+import com.doomhamsters.cards.definitions.SignOfFateCardDefinition
 import com.doomhamsters.cards.definitions.SnackStashCardDefinition
 import com.doomhamsters.cards.definitions.SniffAheadCardDefinition
 import com.doomhamsters.cards.definitions.BegForSnacksCardDefinition
 import com.doomhamsters.model.Card
 import com.doomhamsters.model.CardType
-import com.doomhamsters.cards.definitions.SignOfFateCardDefinition
 
 /** Resolves card definitions and command metadata for known cards. */
 object CardRegistry {

--- a/app/src/main/java/com/doomhamsters/cards/CardRegistry.kt
+++ b/app/src/main/java/com/doomhamsters/cards/CardRegistry.kt
@@ -11,6 +11,7 @@ import com.doomhamsters.cards.definitions.QuickPeekCardDefinition
 import com.doomhamsters.cards.definitions.SnackStashCardDefinition
 import com.doomhamsters.model.Card
 import com.doomhamsters.model.CardType
+import com.doomhamsters.cards.definitions.SignOfFateCardDefinition
 
 /** Resolves card definitions and command metadata for known cards. */
 object CardRegistry {
@@ -19,6 +20,7 @@ object CardRegistry {
         SnackStashCardDefinition,
         PowerNapCardDefinition,
         QuickPeekCardDefinition,
+        SignOfFateCardDefinition,
         NormalCardDefinition
     )
 

--- a/app/src/main/java/com/doomhamsters/cards/definitions/SignOfFateCardDefinition.kt
+++ b/app/src/main/java/com/doomhamsters/cards/definitions/SignOfFateCardDefinition.kt
@@ -1,0 +1,36 @@
+package com.doomhamsters.cards.definitions
+
+import com.doomhamsters.cards.CardCommandId
+import com.doomhamsters.logic.cardcommands.CardCommand
+import com.doomhamsters.logic.cardcommands.CardCommandContext
+import com.doomhamsters.logic.cardcommands.CardCommandOutcome
+import com.doomhamsters.model.CardType
+
+/** Defines the Sign of Fate card and its life-gain activation behavior. */
+object SignOfFateCardDefinition : CardDefinition {
+
+    override val type: CardType = CardType.SignOfFate
+
+    override val displayName: String = "Sign of Fate"
+
+    override val description: String = "Gain 1 life."
+
+    override val command: CardCommandDefinition = CardCommandDefinition(
+        id = CardCommandId.SIGN_OF_FATE,
+        executor = SignOfFateCommand
+    )
+
+    private object SignOfFateCommand : CardCommand {
+
+        override val id: CardCommandId = CardCommandId.SIGN_OF_FATE
+
+        override fun execute(context: CardCommandContext): CardCommandOutcome {
+            context.engine.discardFromHand(context.player, context.card)
+
+            return CardCommandOutcome(
+                publicMessage = "${context.player.name} activated $displayName.",
+                endsTurn = false
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/doomhamsters/model/Card.kt
+++ b/app/src/main/java/com/doomhamsters/model/Card.kt
@@ -10,6 +10,7 @@ enum class CardType {
     SnackStash,
     PowerNap,
     QuickPeek,
+    SignOfFate,
     Normal;
 
     companion object {

--- a/app/src/main/java/com/doomhamsters/model/Card.kt
+++ b/app/src/main/java/com/doomhamsters/model/Card.kt
@@ -20,6 +20,7 @@ enum class CardType {
             "SNACK_STASH", "SNACKSTASH" -> SnackStash
             "POWER_NAP", "POWERNAP" -> PowerNap
             "QUICK_PEEK", "QUICKPEEK" -> QuickPeek
+            "SIGN_OF_FATE", "SIGNOFFATE" -> SignOfFate
             "NORMAL" -> Normal
             else -> runCatching { valueOf(value) }.getOrDefault(Normal)
         }

--- a/app/src/main/java/com/doomhamsters/ui/gameboard/CardFaces.kt
+++ b/app/src/main/java/com/doomhamsters/ui/gameboard/CardFaces.kt
@@ -60,6 +60,7 @@ fun CardFaceUp(card: Card, isSelected: Boolean, isDefocused: Boolean, modifier: 
         CardType.SnackStash -> Triple(SnackStashColor, Color(0xFFA3C968), CardDarkMaroon)
         CardType.PowerNap -> Triple(Color(0xFFB8D8E8), Color(0xFF6A9FB5), CardDarkMaroon)
         CardType.QuickPeek -> Triple(Color(0xFFF8E7A2), Color(0xFFD6A93A), CardDarkMaroon)
+        CardType.SignOfFate -> Triple(Color(0xFFDCC8FF), Color(0xFF8B6BC7), CardDarkMaroon)
         CardType.Normal -> Triple(BackgroundCream, AccentOrange, CardDarkMaroon)
     }
 


### PR DESCRIPTION
Summary

Add frontend support for the Sign of Fate card.

Changes
Added SignOfFateCardDefinition
Added SIGN_OF_FATE command support
Added SignOfFate card type mapping
Registered Sign of Fate in CardRegistry
Added Sign of Fate card styling in CardFaces
Added card description and display metadata
Enabled sending Sign of Fate activation requests to the backend