### PR TITLE
Refectoring game board

### DIFF
--- a/app/src/main/java/com/doomhamsters/ui/GameBoard.kt
+++ b/app/src/main/java/com/doomhamsters/ui/GameBoard.kt
@@ -29,7 +29,6 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import com.doomhamsters.viewmodel.ConnectionStatus
-import com.doomhamsters.cards.CardCommandNotice
 import com.doomhamsters.model.Card
 import com.doomhamsters.model.GameState
 import com.doomhamsters.model.CardType
@@ -47,31 +46,6 @@ private sealed interface GameBoardResolution {
     data class Status(val message: String) : GameBoardResolution
 }
 
-private data class BoardOverlayState(
-    val pendingDoom: Card?,
-    val pendingDoomMessage: String?,
-    val pendingDoomRequiresSelection: Boolean,
-    val pendingDoomRequiresInsertionUi: Boolean,
-    val pausedRemotePlayerName: String?,
-    val pausedForDoomPlayerName: String?,
-    val pausedForDoomMessage: String?,
-    val pausedForDoomDetail: String?,
-    val cardCommandNotice: CardCommandNotice?
-)
-
-private data class BoardOverlayContext(
-    val currentPlayer: Player,
-    val deckSize: Int,
-    val selectedPlayerCardIndex: Int,
-    val doomSliderPosition: Float
-)
-
-private data class BoardOverlayCallbacks(
-    val onDoomSliderChange: (Float) -> Unit,
-    val onDoomConfirmed: () -> Unit,
-    val onDoomDismiss: () -> Unit,
-    val onCardCommandDismiss: () -> Unit
-)
 
 private data class HandDrawState(
     val localAnimatingCardIndex: Int,
@@ -355,7 +329,10 @@ fun GameBoard(
                             selectedPlayerCardIndex = -1
                         },
                         onDoomDismiss = { viewModel.dismissDoomNotice(selectedPlayerCardIndex) },
-                        onCardCommandDismiss = viewModel::dismissCardCommandNotice
+                        onCardCommandDismiss = viewModel::dismissCardCommandNotice,
+                        onAcceptDoom = {},
+                                onSnackStashVote = { _, _ -> },
+                        onSnackStashResolutionDismiss = {}
                     )
                 )
 
@@ -572,59 +549,7 @@ private suspend fun runDrawAnimation(drawAnimatable: Animatable<Float, Animation
     )
 }
 
-@Composable
-private fun BoardOverlays(
-    overlayState: BoardOverlayState,
-    context: BoardOverlayContext,
-    callbacks: BoardOverlayCallbacks
-) {
-    when {
-        overlayState.pendingDoom != null && overlayState.pendingDoomRequiresInsertionUi -> {
-            DoomOverlay(
-                state = DoomOverlayState(
-                    pendingDoom = overlayState.pendingDoom,
-                    deckSize = context.deckSize,
-                    currentPlayer = context.currentPlayer,
-                    selectedPlayerCardIndex = context.selectedPlayerCardIndex,
-                    hasDefused = true,
-                    doomSliderPosition = context.doomSliderPosition
-                ),
-                onDefuseTriggered = {},
-                onDoomSliderChange = callbacks.onDoomSliderChange,
-                onDoomConfirmed = callbacks.onDoomConfirmed,
-                onAcceptDoom = {}
-            )
-        }
 
-        overlayState.pendingDoom != null && overlayState.pendingDoomMessage != null -> {
-            DoomResolvedOverlay(
-                card = overlayState.pendingDoom,
-                currentPlayer = context.currentPlayer,
-                selectedPlayerCardIndex = context.selectedPlayerCardIndex,
-                message = overlayState.pendingDoomMessage,
-                requiresSnackSelection = overlayState.pendingDoomRequiresSelection,
-                onDismiss = callbacks.onDoomDismiss
-            )
-        }
-
-        overlayState.pausedForDoomPlayerName != null &&
-            overlayState.pausedForDoomMessage != null &&
-            overlayState.pausedForDoomDetail != null -> {
-            RemoteDoomPauseOverlay(
-                playerName = overlayState.pausedRemotePlayerName ?: overlayState.pausedForDoomPlayerName,
-                message = overlayState.pausedForDoomMessage,
-                detail = overlayState.pausedForDoomDetail
-            )
-        }
-    }
-
-    overlayState.cardCommandNotice?.let { notice ->
-        CardCommandNoticeOverlay(
-            notice = notice,
-            onDismiss = callbacks.onCardCommandDismiss
-        )
-    }
-}
 
 @Composable
 private fun GameBoardStatus(message: String, onLeaveGame: () -> Unit = {}) {

--- a/app/src/main/java/com/doomhamsters/ui/gameboard/BoardOverlays.kt
+++ b/app/src/main/java/com/doomhamsters/ui/gameboard/BoardOverlays.kt
@@ -1,0 +1,109 @@
+package com.doomhamsters.ui.gameboard
+import androidx.compose.runtime.Composable
+import com.doomhamsters.cards.CardCommandNotice
+//import com.doomhamsters.cheating.presentation.SnackStashNoticeKind
+//import com.doomhamsters.cheating.presentation.SnackStashNoticeState
+import com.doomhamsters.model.Card
+import com.doomhamsters.model.Player
+//import com.doomhamsters.ui.cheating.SnackStashClaimPromptOverlay
+//import com.doomhamsters.ui.cheating.SnackStashNoticeOverlay
+internal data class BoardOverlayState(
+    val pendingDoom: Card?,
+    val pendingDoomMessage: String?,
+    val pendingDoomRequiresSelection: Boolean,
+    val pendingDoomRequiresInsertionUi: Boolean,
+    val pausedRemotePlayerName: String?,
+    val pausedForDoomPlayerName: String?,
+    val pausedForDoomMessage: String?,
+    val pausedForDoomDetail: String?,
+    val cardCommandNotice: CardCommandNotice?,
+    //val snackStashNoticeState: SnackStashNoticeState
+)
+
+internal data class BoardOverlayContext(
+    val currentPlayer: Player,
+    val deckSize: Int,
+    val selectedPlayerCardIndex: Int,
+    val doomSliderPosition: Float
+)
+
+internal data class BoardOverlayCallbacks(
+    val onDoomSliderChange: (Float) -> Unit,
+    val onDoomConfirmed: () -> Unit,
+    val onDoomDismiss: () -> Unit,
+    val onAcceptDoom: () -> Unit,
+    val onCardCommandDismiss: () -> Unit,
+    val onSnackStashVote: (String, Boolean) -> Unit,
+    val onSnackStashResolutionDismiss: () -> Unit
+)
+
+@Composable
+internal fun BoardOverlays(
+    overlayState: BoardOverlayState,
+    context: BoardOverlayContext,
+    callbacks: BoardOverlayCallbacks
+) {
+    //if (overlayState.snackStashNoticeState.kind != SnackStashNoticeKind.NONE) {
+        //SnackStashNoticeOverlay(
+          //  state = overlayState.snackStashNoticeState,
+           // onVote = callbacks.onSnackStashVote,
+           // onResolutionDismiss = callbacks.onSnackStashResolutionDismiss
+       // )
+  //  } else {
+        when {
+            overlayState.pendingDoom != null && overlayState.pendingDoomRequiresInsertionUi -> {
+                DoomOverlay(
+                    state = DoomOverlayState(
+                        pendingDoom = overlayState.pendingDoom,
+                        deckSize = context.deckSize,
+                        currentPlayer = context.currentPlayer,
+                        selectedPlayerCardIndex = context.selectedPlayerCardIndex,
+                        hasDefused = true,
+                        doomSliderPosition = context.doomSliderPosition
+                    ),
+                    onDefuseTriggered = {},
+                    onDoomSliderChange = callbacks.onDoomSliderChange,
+                    onDoomConfirmed = callbacks.onDoomConfirmed,
+                    onAcceptDoom = {}
+                )
+            }
+
+            //overlayState.pendingDoom != null && overlayState.pendingDoomRequiresSelection -> {
+                //SnackStashClaimPromptOverlay(
+                    //pendingDoom = overlayState.pendingDoom,
+                   // message = overlayState.pendingDoomMessage
+                    //    ?: "Use Snack Stash, bluff with another card, or accept Doom.",
+                   // onAcceptDoom = callbacks.onAcceptDoom
+               // )
+           // }
+
+            overlayState.pendingDoom != null && overlayState.pendingDoomMessage != null -> {
+                DoomResolvedOverlay(
+                    card = overlayState.pendingDoom,
+                    currentPlayer = context.currentPlayer,
+                    selectedPlayerCardIndex = context.selectedPlayerCardIndex,
+                    message = overlayState.pendingDoomMessage,
+                    requiresSnackSelection = overlayState.pendingDoomRequiresSelection,
+                    onDismiss = callbacks.onDoomDismiss
+                )
+            }
+
+            overlayState.pausedForDoomPlayerName != null &&
+                    overlayState.pausedForDoomMessage != null &&
+                    overlayState.pausedForDoomDetail != null -> {
+                RemoteDoomPauseOverlay(
+                    playerName = overlayState.pausedRemotePlayerName ?: overlayState.pausedForDoomPlayerName,
+                    message = overlayState.pausedForDoomMessage,
+                    detail = overlayState.pausedForDoomDetail
+                )
+            }
+        }
+    //}
+
+    overlayState.cardCommandNotice?.let { notice ->
+        CardCommandNoticeOverlay(
+            notice = notice,
+            onDismiss = callbacks.onCardCommandDismiss
+        )
+    }
+}


### PR DESCRIPTION
Extraction: Created BoardOverlays.kt in com.doomhamsters.ui.gameboard.

Moved State & Logic: Relocated BoardOverlayState, BoardOverlayContext, BoardOverlayCallbacks, and the main BoardOverlays Composable to the new file.

Cleaned Main UI: Removed the extracted classes and functions from GameBoard.kt and updated the implementation call.

Team Integration Prep: Added the necessary callback parameters (onAcceptDoom, onSnackStashVote, etc.) to prepare for Maxim's upcoming cheat-feature PR. (Note: The specific SnackStash overlay calls are temporarily commented out in this branch to ensure it compiles smoothly until the cheat PR is merged into main).