### PR TITLE
Sniff Ahead Card Effect

### DIFF
--- a/app/src/main/java/com/doomhamsters/cards/CardCommandId.kt
+++ b/app/src/main/java/com/doomhamsters/cards/CardCommandId.kt
@@ -4,7 +4,8 @@ package com.doomhamsters.cards
 /** Lists the supported activatable card command identifiers. */
 enum class CardCommandId {
     POWER_NAP,
-    QUICK_PEEK;
+    QUICK_PEEK,
+    SNIFF_AHEAD;
 
     companion object {
         /** Maps backend wire values to a known card command identifier. */

--- a/app/src/main/java/com/doomhamsters/cards/CardCommandModels.kt
+++ b/app/src/main/java/com/doomhamsters/cards/CardCommandModels.kt
@@ -37,7 +37,8 @@ data class CardCommandEvent(
     val playerName: String?,
     val message: String?,
     val card: Card?,
-    val revealedCard: Card?
+    val revealedCard: Card?,
+    val revealedCards: List<Card> = emptyList()
 ) {
     companion object {
         /** Parses a backend JSON payload into a card-command event when possible. */
@@ -45,6 +46,15 @@ data class CardCommandEvent(
             val type = runCatching {
                 CardCommandEventType.valueOf(json.optString("type").trim().uppercase())
             }.getOrNull() ?: return null
+
+            val revealedCardsArray = json.optJSONArray("revealedCards")
+            val revealedCards = buildList {
+                if (revealedCardsArray != null) {
+                    for (i in 0 until revealedCardsArray.length()) {
+                        revealedCardsArray.optJSONObject(i)?.let { add(Card.fromJson(it)) }
+                    }
+                }
+            }
 
             return CardCommandEvent(
                 type = type,
@@ -57,7 +67,8 @@ data class CardCommandEvent(
                 playerName = json.optNullableString("playerName"),
                 message = json.optNullableString("message"),
                 card = json.optJSONObject("card")?.let(Card::fromJson),
-                revealedCard = json.optJSONObject("revealedCard")?.let(Card::fromJson)
+                revealedCard = json.optJSONObject("revealedCard")?.let(Card::fromJson),
+                revealedCards = revealedCards
             )
         }
 
@@ -70,5 +81,6 @@ data class CardCommandEvent(
 data class CardCommandNotice(
     val title: String,
     val message: String,
-    val revealedCard: Card? = null
+    val revealedCard: Card? = null,
+    val revealedCards: List<Card> = emptyList()
 )

--- a/app/src/main/java/com/doomhamsters/cards/CardRegistry.kt
+++ b/app/src/main/java/com/doomhamsters/cards/CardRegistry.kt
@@ -9,6 +9,7 @@ import com.doomhamsters.cards.definitions.NormalCardDefinition
 import com.doomhamsters.cards.definitions.PowerNapCardDefinition
 import com.doomhamsters.cards.definitions.QuickPeekCardDefinition
 import com.doomhamsters.cards.definitions.SnackStashCardDefinition
+import com.doomhamsters.cards.definitions.SniffAheadCardDefinition
 import com.doomhamsters.model.Card
 import com.doomhamsters.model.CardType
 
@@ -19,6 +20,7 @@ object CardRegistry {
         SnackStashCardDefinition,
         PowerNapCardDefinition,
         QuickPeekCardDefinition,
+        SniffAheadCardDefinition,
         NormalCardDefinition
     )
 

--- a/app/src/main/java/com/doomhamsters/cards/definitions/SniffAheadCardDefinition.kt
+++ b/app/src/main/java/com/doomhamsters/cards/definitions/SniffAheadCardDefinition.kt
@@ -1,0 +1,42 @@
+package com.doomhamsters.cards.definitions
+
+import com.doomhamsters.cards.CardCommandId
+import com.doomhamsters.cards.displayName
+import com.doomhamsters.logic.cardcommands.CardCommand
+import com.doomhamsters.logic.cardcommands.CardCommandContext
+import com.doomhamsters.logic.cardcommands.CardCommandOutcome
+import com.doomhamsters.model.CardType
+
+/** Defines the Sniff Ahead card and its private top-3 peek behavior. */
+object SniffAheadCardDefinition : CardDefinition {
+    override val type: CardType = CardType.SniffAhead
+    override val displayName: String = "Sniff Ahead"
+    override val description: String = "Secretly look at the top 3 cards of the deck."
+    override val command: CardCommandDefinition = CardCommandDefinition(
+        id = CardCommandId.SNIFF_AHEAD,
+        privateResult = true,
+        executor = SniffAheadCommand
+    )
+
+    private object SniffAheadCommand : CardCommand {
+        override val id: CardCommandId = CardCommandId.SNIFF_AHEAD
+
+        override fun execute(context: CardCommandContext): CardCommandOutcome {
+            context.engine.discardFromHand(context.player, context.card)
+            val topCards = context.engine.peekTopCards(3)
+
+            val privateMessage = if (topCards.isEmpty()) {
+                "The deck is empty."
+            } else {
+                "Top ${topCards.size} card(s): ${topCards.joinToString(", ") { it.displayName() }}."
+            }
+
+            return CardCommandOutcome(
+                publicMessage = "${context.player.name} activated $displayName.",
+                privateMessage = privateMessage,
+                revealedCards = topCards,
+                endsTurn = false
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/doomhamsters/logic/GameEngine.kt
+++ b/app/src/main/java/com/doomhamsters/logic/GameEngine.kt
@@ -116,4 +116,7 @@ class GameEngine(playerIds: ArrayList<String>) : CardCommandSupport {
     /** Returns the top card of the deck without drawing it. */
     override fun peekTopCard(): Card? = gameState.deck.peekTop()
 
+    /** Returns up to [n] top cards of the deck without drawing them, top card first. */
+    override fun peekTopCards(n: Int): List<Card> = gameState.deck.peekTopN(n)
+
 }

--- a/app/src/main/java/com/doomhamsters/logic/cardcommands/CardCommand.kt
+++ b/app/src/main/java/com/doomhamsters/logic/cardcommands/CardCommand.kt
@@ -27,6 +27,7 @@ data class CardCommandOutcome(
     val publicMessage: String,
     val privateMessage: String? = null,
     val revealedCard: Card? = null,
+    val revealedCards: List<Card> = emptyList(),
     val endsTurn: Boolean = false
 )
 
@@ -36,4 +37,6 @@ interface CardCommandSupport {
     fun discardFromHand(player: Player, card: Card)
     /** Returns the current top card of the deck without removing it. */
     fun peekTopCard(): Card?
+    /** Returns up to [n] top cards of the deck without removing them, top card first. */
+    fun peekTopCards(n: Int): List<Card>
 }

--- a/app/src/main/java/com/doomhamsters/model/Card.kt
+++ b/app/src/main/java/com/doomhamsters/model/Card.kt
@@ -10,6 +10,7 @@ enum class CardType {
     SnackStash,
     PowerNap,
     QuickPeek,
+    SniffAhead,
     Normal;
 
     companion object {
@@ -19,6 +20,7 @@ enum class CardType {
             "SNACK_STASH", "SNACKSTASH" -> SnackStash
             "POWER_NAP", "POWERNAP" -> PowerNap
             "QUICK_PEEK", "QUICKPEEK" -> QuickPeek
+            "SNIFF_AHEAD", "SNIFFAHEAD" -> SniffAhead
             "NORMAL" -> Normal
             else -> runCatching { valueOf(value) }.getOrDefault(Normal)
         }

--- a/app/src/main/java/com/doomhamsters/model/Deck.kt
+++ b/app/src/main/java/com/doomhamsters/model/Deck.kt
@@ -10,6 +10,8 @@ class Deck {
     fun size(): Int = cards.size
     /** Returns the current top card without removing it. */
     fun peekTop(): Card? = cards.lastOrNull()
+    /** Returns up to [n] top cards without removing them, top card first. */
+    fun peekTopN(n: Int): List<Card> = cards.takeLast(n).reversed()
 
     /** Removes and returns the current top card. */
     fun draw(): Card? {

--- a/app/src/main/java/com/doomhamsters/ui/gameboard/CardCommandNoticeOverlay.kt
+++ b/app/src/main/java/com/doomhamsters/ui/gameboard/CardCommandNoticeOverlay.kt
@@ -4,11 +4,14 @@ package com.doomhamsters.ui.gameboard
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -62,14 +65,20 @@ fun CardCommandNoticeOverlay(
                 textAlign = TextAlign.Center
             )
             notice.revealedCard?.let { revealedCard ->
-                Box(
-                    modifier = Modifier.padding(top = 4.dp)
+                Box(modifier = Modifier.padding(top = 4.dp)) {
+                    CardFaceUp(card = revealedCard, isSelected = false, isDefocused = false)
+                }
+            }
+            if (notice.revealedCards.isNotEmpty()) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier
+                        .padding(top = 4.dp)
+                        .horizontalScroll(rememberScrollState())
                 ) {
-                    CardFaceUp(
-                        card = revealedCard,
-                        isSelected = false,
-                        isDefocused = false
-                    )
+                    notice.revealedCards.forEach { revealedCard ->
+                        CardFaceUp(card = revealedCard, isSelected = false, isDefocused = false)
+                    }
                 }
             }
             Text(

--- a/app/src/main/java/com/doomhamsters/ui/gameboard/CardFaces.kt
+++ b/app/src/main/java/com/doomhamsters/ui/gameboard/CardFaces.kt
@@ -60,6 +60,7 @@ fun CardFaceUp(card: Card, isSelected: Boolean, isDefocused: Boolean, modifier: 
         CardType.SnackStash -> Triple(SnackStashColor, Color(0xFFA3C968), CardDarkMaroon)
         CardType.PowerNap -> Triple(Color(0xFFB8D8E8), Color(0xFF6A9FB5), CardDarkMaroon)
         CardType.QuickPeek -> Triple(Color(0xFFF8E7A2), Color(0xFFD6A93A), CardDarkMaroon)
+        CardType.SniffAhead -> Triple(Color(0xFFD4EED4), Color(0xFF6AAF6A), CardDarkMaroon)
         CardType.Normal -> Triple(BackgroundCream, AccentOrange, CardDarkMaroon)
     }
 

--- a/app/src/main/java/com/doomhamsters/viewmodel/GameBoardViewModel.kt
+++ b/app/src/main/java/com/doomhamsters/viewmodel/GameBoardViewModel.kt
@@ -253,6 +253,19 @@ open class GameBoardViewModel(
                             revealedCard = parsedEvent.revealedCard
                         )
                     }
+                    CardCommandId.SNIFF_AHEAD -> {
+                        val title = parsedEvent.card?.displayName() ?: "Sniff Ahead"
+                        val message = parsedEvent.message
+                            ?: if (parsedEvent.revealedCards.isEmpty()) "The deck is empty."
+                            else "Top ${parsedEvent.revealedCards.size} card(s): ${
+                                parsedEvent.revealedCards.joinToString(", ") { it.displayName() }
+                            }."
+                        _cardCommandNotice.value = CardCommandNotice(
+                            title = title,
+                            message = message,
+                            revealedCards = parsedEvent.revealedCards
+                        )
+                    }
                     else -> Unit
                 }
             }

--- a/app/src/test/java/com/doomhamsters/cards/CardRegistryTest.kt
+++ b/app/src/test/java/com/doomhamsters/cards/CardRegistryTest.kt
@@ -29,6 +29,16 @@ class CardRegistryTest {
     }
 
     @Test
+    fun `sniff ahead is registered as private result command card`() {
+        val definition = CardRegistry.definitionForType(CardType.SniffAhead)
+
+        assertEquals("Sniff Ahead", definition.displayName)
+        assertEquals(CardCommandId.SNIFF_AHEAD, definition.command?.id)
+        assertTrue(definition.command?.privateResult == true)
+        assertFalse(definition.command?.endsTurn == true)
+    }
+
+    @Test
     fun `normal card remains non activatable`() {
         val definition = CardRegistry.definitionFor(Card(CardType.Normal))
 


### PR DESCRIPTION
Adds the Sniff Ahead card command that privately reveals the top 3 deck cards to the acting player without changing deck order.

## Changes
- Add SniffAhead to CardType, SNIFF_AHEAD to CardCommandId
- Add Deck.peekTopN, CardCommandSupport.peekTopCards, CardCommandOutcome.revealedCards
- Extend CardCommandEvent and CardCommandNotice with revealedCards list
- Add SniffAheadCardDefinition, register in CardRegistry, add card face color
- Handle SNIFF_AHEAD private event and render revealed cards in overlay

## Tests
- CardRegistryTest: SniffAhead registered as private-result non-turn-ending command

Closes #178, #179, #180, #181, #182, #183