### PR TITLE
Tunnel Chaos — shuffle the draw deck

### DIFF
--- a/app/src/main/java/com/doomhamsters/cards/CardCommandId.kt
+++ b/app/src/main/java/com/doomhamsters/cards/CardCommandId.kt
@@ -11,8 +11,6 @@ enum class CardCommandId {
     QUICK_PEEK,
     SNIFF_AHEAD,
     TUNNEL_CHAOS,
-    HYPER_MODE,
-    SIGN_OF_FATE,
     STEAL_CARD;
 
 

--- a/app/src/main/java/com/doomhamsters/cards/CardCommandId.kt
+++ b/app/src/main/java/com/doomhamsters/cards/CardCommandId.kt
@@ -5,7 +5,8 @@ package com.doomhamsters.cards
 enum class CardCommandId {
     POWER_NAP,
     BEG_FOR_SNACKS,
-    QUICK_PEEK;
+    QUICK_PEEK,
+    TUNNEL_CHAOS;
 
     companion object {
         /** Maps backend wire values to a known card command identifier. */

--- a/app/src/main/java/com/doomhamsters/cards/CardCommandId.kt
+++ b/app/src/main/java/com/doomhamsters/cards/CardCommandId.kt
@@ -7,9 +7,8 @@ enum class CardCommandId {
     BEG_FOR_SNACKS,
     QUICK_PEEK,
     SNIFF_AHEAD,
-    TUNNEL_CHAOS;
-    HYPER_MODE,
-  
+    TUNNEL_CHAOS,
+    HYPER_MODE;
 
     companion object {
         /** Maps backend wire values to a known card command identifier. */

--- a/app/src/main/java/com/doomhamsters/cards/CardRegistry.kt
+++ b/app/src/main/java/com/doomhamsters/cards/CardRegistry.kt
@@ -11,6 +11,7 @@ import com.doomhamsters.cards.definitions.QuickPeekCardDefinition
 import com.doomhamsters.cards.definitions.SnackStashCardDefinition
 import com.doomhamsters.cards.definitions.SniffAheadCardDefinition
 import com.doomhamsters.cards.definitions.BegForSnacksCardDefinition
+import com.doomhamsters.cards.definitions.TunnelChaosCardDefinition
 import com.doomhamsters.model.Card
 import com.doomhamsters.model.CardType
 
@@ -23,6 +24,7 @@ object CardRegistry {
         QuickPeekCardDefinition,
         SniffAheadCardDefinition,
         BegForSnacksCardDefinition,
+        TunnelChaosCardDefinition,
         NormalCardDefinition
     )
 

--- a/app/src/main/java/com/doomhamsters/cards/definitions/TunnelChaosCardDefinition.kt
+++ b/app/src/main/java/com/doomhamsters/cards/definitions/TunnelChaosCardDefinition.kt
@@ -1,0 +1,15 @@
+package com.doomhamsters.cards.definitions
+
+import com.doomhamsters.cards.CardCommandId
+import com.doomhamsters.model.CardType
+
+/** Defines the Tunnel Chaos card; the backend shuffles the deck when it is activated. */
+object TunnelChaosCardDefinition : CardDefinition {
+    override val type: CardType = CardType.TunnelChaos
+    override val displayName: String = "Tunnel Chaos"
+    override val description: String = "Shuffle the deck."
+    override val command: CardCommandDefinition = CardCommandDefinition(
+        id = CardCommandId.TUNNEL_CHAOS
+        // no executor — the backend performs the shuffle
+    )
+}

--- a/app/src/main/java/com/doomhamsters/model/Card.kt
+++ b/app/src/main/java/com/doomhamsters/model/Card.kt
@@ -11,6 +11,7 @@ enum class CardType {
     PowerNap,
     BegForSnacks,
     QuickPeek,
+    TunnelChaos,
     Normal;
 
     companion object {
@@ -21,6 +22,7 @@ enum class CardType {
             "POWER_NAP", "POWERNAP" -> PowerNap
             "QUICK_PEEK", "QUICKPEEK" -> QuickPeek
             "BEG_FOR_SNACKS", "BEGFORSNACKS" -> BegForSnacks
+            "TUNNEL_CHAOS", "TUNNELCHAOS" -> TunnelChaos
             "NORMAL" -> Normal
             else -> runCatching { valueOf(value) }.getOrDefault(Normal)
         }

--- a/app/src/main/java/com/doomhamsters/ui/gameboard/CardFaces.kt
+++ b/app/src/main/java/com/doomhamsters/ui/gameboard/CardFaces.kt
@@ -61,6 +61,7 @@ fun CardFaceUp(card: Card, isSelected: Boolean, isDefocused: Boolean, modifier: 
         CardType.PowerNap -> Triple(Color(0xFFB8D8E8), Color(0xFF6A9FB5), CardDarkMaroon)
         CardType.QuickPeek -> Triple(Color(0xFFF8E7A2), Color(0xFFD6A93A), CardDarkMaroon)
         CardType.BegForSnacks -> Triple(Color(0xFFE8C9A0), Color(0xFFB8864E), CardDarkMaroon)
+        CardType.TunnelChaos -> Triple(Color(0xFFCBB6E0), Color(0xFF8E6FB0), CardDarkMaroon)
         CardType.Normal -> Triple(BackgroundCream, AccentOrange, CardDarkMaroon)
     }
 

--- a/app/src/test/java/com/doomhamsters/cards/CardRegistryTest.kt
+++ b/app/src/test/java/com/doomhamsters/cards/CardRegistryTest.kt
@@ -39,6 +39,17 @@ class CardRegistryTest {
     }
 
     @Test
+    fun `tunnel chaos is registered as a playable command card`() {
+        val definition = CardRegistry.definitionForType(CardType.TunnelChaos)
+
+        assertEquals("Tunnel Chaos", definition.displayName)
+        assertEquals(CardCommandId.TUNNEL_CHAOS, definition.command?.id)
+        assertTrue(definition.command != null)
+        assertFalse(definition.command?.endsTurn == true)
+        assertTrue(definition.command?.executor == null)
+    }
+
+    @Test
     fun `normal card remains non activatable`() {
         val definition = CardRegistry.definitionFor(Card(CardType.Normal))
 


### PR DESCRIPTION
Adds the full frontend for the Tunnel Chaos card: it shows with its own card face, is registered as a playable card, and its activate command resolves against the backend. The shuffle itself is handled by the backend.

* New CardType.TunnelChaos with a fromWire alias for the backend value ("TunnelChaos" → TUNNELCHAOS)
* New CardCommandId.TUNNEL_CHAOS — fromWire is generic, so it resolves automatically
* CardFaces.kt: color branch for the new type, keeping the exhaustive when() compiling
* New TunnelChaosCardDefinition (command TUNNEL_CHAOS, no executor — the backend shuffles) and registered in CardRegistry, so the card is actually playable
* CardRegistryTest: covers the new definition (registration, command id, display name, no local executor)

Closes #198
Closes #199
Closes #200