### PR TITLE
Squick cancel last action

### DIFF
--- a/app/src/main/java/com/doomhamsters/cards/CardCommandId.kt
+++ b/app/src/main/java/com/doomhamsters/cards/CardCommandId.kt
@@ -13,7 +13,8 @@ enum class CardCommandId {
     SNIFF_AHEAD,
     CAGE_SWAP,
     TUNNEL_CHAOS,
-    STEAL_CARD;
+    STEAL_CARD,
+    SQUICK;
 
 
     companion object {

--- a/app/src/main/java/com/doomhamsters/cards/CardRegistry.kt
+++ b/app/src/main/java/com/doomhamsters/cards/CardRegistry.kt
@@ -13,6 +13,7 @@ import com.doomhamsters.cards.definitions.PowerNapCardDefinition
 import com.doomhamsters.cards.definitions.QuickPeekCardDefinition
 import com.doomhamsters.cards.definitions.SignOfFateCardDefinition
 import com.doomhamsters.cards.definitions.SnackStashCardDefinition
+import com.doomhamsters.cards.definitions.SquickCardDefinition
 import com.doomhamsters.cards.definitions.StealCardDefinition
 import com.doomhamsters.cards.definitions.SniffAheadCardDefinition
 import com.doomhamsters.cards.definitions.BegForSnacksCardDefinition
@@ -37,6 +38,7 @@ object CardRegistry {
         TunnelChaosCardDefinition,
         StealCardDefinition,
         TwoHamstersCardDefinition,
+        SquickCardDefinition,
         NormalCardDefinition
     )
 

--- a/app/src/main/java/com/doomhamsters/cards/definitions/SquickCardDefinition.kt
+++ b/app/src/main/java/com/doomhamsters/cards/definitions/SquickCardDefinition.kt
@@ -1,0 +1,16 @@
+package com.doomhamsters.cards.definitions
+
+import com.doomhamsters.cards.CardCommandId
+import com.doomhamsters.model.CardType
+
+/** Defines the Squick card that cancels the most recently executed card effect. */
+object SquickCardDefinition : CardDefinition {
+    override val type: CardType = CardType.Squick
+    override val displayName: String = "Squick"
+    override val description: String =
+        "Cancel the most recently played card effect and restore the game to its previous state."
+    override val command: CardCommandDefinition = CardCommandDefinition(
+        id = CardCommandId.SQUICK,
+        executor = null
+    )
+}

--- a/app/src/main/java/com/doomhamsters/model/Card.kt
+++ b/app/src/main/java/com/doomhamsters/model/Card.kt
@@ -19,6 +19,7 @@ enum class CardType {
     FourHamsters,
     StealCard,
     TwoHamsters,
+    Squick,
     Normal;
 
     companion object {
@@ -37,6 +38,7 @@ enum class CardType {
             "HYPER_MODE", "HYPERMODE" -> HyperMode
             "HAMSTER_FOUR", "HAMSTER4", "HAMSTERTWO" -> FourHamsters
             "HAMSTER_TWO", "HAMSTER2" -> TwoHamsters
+            "SQUICK" -> Squick
             "NORMAL" -> Normal
             else -> runCatching { valueOf(value) }.getOrDefault(Normal)
         }

--- a/app/src/main/java/com/doomhamsters/ui/gameboard/CardFaces.kt
+++ b/app/src/main/java/com/doomhamsters/ui/gameboard/CardFaces.kt
@@ -69,6 +69,7 @@ fun CardFaceUp(card: Card, isSelected: Boolean, isDefocused: Boolean, modifier: 
         CardType.HyperMode -> Triple(Color(0xFFFFA726), Color(0xFFF57C00), CardDarkMaroon)
         CardType.StealCard -> Triple(Color(0xFFF8E7A2), Color(0xFFD6A93A), CardDarkMaroon)
         CardType.TwoHamsters -> Triple(Color(0xFFCE93D8), Color(0xFFAB47BC), CardDarkMaroon)
+        CardType.Squick -> Triple(Color(0xFFB0BEC5), Color(0xFF546E7A), CardDarkMaroon)
         CardType.Normal -> Triple(BackgroundCream, AccentOrange, CardDarkMaroon)
     }
 

--- a/app/src/test/java/com/doomhamsters/cards/CardRegistryTest.kt
+++ b/app/src/test/java/com/doomhamsters/cards/CardRegistryTest.kt
@@ -75,4 +75,16 @@ class CardRegistryTest {
         assertFalse(definition.command?.privateResult == true)
         assertFalse(definition.command?.endsTurn == true)
     }
+
+    @Test
+    fun `squick is registered as a no-target no-private command card`() {
+        val definition = CardRegistry.definitionForType(CardType.Squick)
+
+        assertEquals("Squick", definition.displayName)
+        assertEquals(CardCommandId.SQUICK, definition.command?.id)
+        assertFalse(definition.command?.privateResult == true)
+        assertFalse(definition.command?.endsTurn == true)
+        assertFalse(definition.command?.requiresTargetPlayer == true)
+        assertTrue(definition.command?.executor == null)
+    }
 }

--- a/app/src/test/java/com/doomhamsters/cards/definitions/SquickCardDefinitionTest.kt
+++ b/app/src/test/java/com/doomhamsters/cards/definitions/SquickCardDefinitionTest.kt
@@ -1,0 +1,56 @@
+package com.doomhamsters.cards.definitions
+
+import com.doomhamsters.cards.CardCommandId
+import com.doomhamsters.model.CardType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class SquickCardDefinitionTest {
+
+    @Test
+    fun `type is Squick`() {
+        assertEquals(CardType.Squick, SquickCardDefinition.type)
+    }
+
+    @Test
+    fun `displayName matches backend`() {
+        assertEquals("Squick", SquickCardDefinition.displayName)
+    }
+
+    @Test
+    fun `description is not blank`() {
+        assert(SquickCardDefinition.description.isNotBlank())
+    }
+
+    @Test
+    fun `command id is SQUICK`() {
+        assertEquals(CardCommandId.SQUICK, SquickCardDefinition.command?.id)
+    }
+
+    @Test
+    fun `command has no executor — delegates entirely to backend`() {
+        assertNull(SquickCardDefinition.command?.executor)
+    }
+
+    @Test
+    fun `command does not end the turn`() {
+        assertFalse(SquickCardDefinition.command?.endsTurn == true)
+    }
+
+    @Test
+    fun `command has no private result`() {
+        assertFalse(SquickCardDefinition.command?.privateResult == true)
+    }
+
+    @Test
+    fun `command requires no target parameters`() {
+        val command = SquickCardDefinition.command
+        assertNotNull(command)
+        assertFalse(command!!.requiresTargetPlayer)
+        assertFalse(command.requiresCardType)
+        assertFalse(command.requiresHamsterType)
+    }
+}


### PR DESCRIPTION
 ## Summary

  - Registers Squick end-to-end following the existing card definition pattern: `CardType` enum entry, `fromWire` alias, `CardCommandId.SQUICK`, `SquickCardDefinition` object, `CardRegistry` entry, and a blue-grey color in `CardFaces`.
  - Squick has no target flags and no executor — the backend handles all state restoration; the frontend just fires the command and waits for the restored `GameState` broadcast.
  - Adds `SquickCardDefinitionTest` (metadata + flag assertions) and a `CardRegistry` round-trip test.

  ## Test plan

  - [ ] `SquickCardDefinitionTest` — all metadata and flag tests pass
  - [ ] `CardRegistryTest.squick is registered as a no-target no-private command card` — passes
  - [ ] Manual: Squick card appears on the board in blue-grey with correct label
  - [ ] Manual: tapping Squick shows an Activate button (no target dialog)
  - [ ] Manual: activating Squick triggers the backend and the board updates to the restored state
  - [ ] Manual: error toast shown when Squick is played with no previous effect