### PR TITLE
Defensive parsing of incoming payloads

### DIFF
--- a/app/src/main/java/com/doomhamsters/GameRepository.kt
+++ b/app/src/main/java/com/doomhamsters/GameRepository.kt
@@ -5,7 +5,7 @@ import android.util.Log
 import com.doomhamsters.model.GameState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -57,9 +57,9 @@ class GameRepository(
     suspend fun subscribeToGameState(gameId: String): Flow<GameState> =
         requireSession()
             .subscribeText("/topic/game-state/$gameId")
-            .map { payload ->
+            .mapNotNull { payload ->
                 Log.d(tag, "WS game-state raw gameId=$gameId payload=$payload")
-                GameState.fromJson(JSONObject(payload)).also { state ->
+                parseGameStateOrNull(payload)?.also { state ->
                     Log.d(
                         tag,
                         "WS game-state parsed gameId=$gameId currentPlayerId=${state.currentTurnPlayerId} turnCount=${state.turnCount} status=${state.status}"
@@ -71,19 +71,37 @@ class GameRepository(
     suspend fun subscribeToPrivateEvents(gameId: String, playerId: String): Flow<JSONObject> =
         requireSession()
             .subscribeText("/queue/game/$gameId/$playerId")
-            .map { payload ->
+            .mapNotNull { payload ->
                 Log.d(tag, "WS private-event gameId=$gameId playerId=$playerId payload=$payload")
-                JSONObject(payload)
+                parsePrivateEventOrNull(payload)
             }
 
     /** Subscribes to player-specific error events for rejected or failed actions. */
     suspend fun subscribeToErrors(gameId: String, playerId: String): Flow<String> =
         requireSession()
             .subscribeText("/queue/game/$gameId/$playerId/errors")
-            .map { payload ->
+            .mapNotNull { payload ->
                 Log.d(tag, "WS error-event gameId=$gameId playerId=$playerId payload=$payload")
-                JSONObject(payload).optString("message", "An error occurred.")
+                parseErrorMessageOrNull(payload)
             }
+
+    /** Parses a game-state payload, logging and dropping it (returns null) when malformed. */
+    internal fun parseGameStateOrNull(payload: String): GameState? =
+        runCatching { GameState.fromJson(JSONObject(payload)) }
+            .onFailure { Log.w(tag, "Dropping malformed game-state payload", it) }
+            .getOrNull()
+
+    /** Parses a private-event payload, logging and dropping it (returns null) when malformed. */
+    internal fun parsePrivateEventOrNull(payload: String): JSONObject? =
+        runCatching { JSONObject(payload) }
+            .onFailure { Log.w(tag, "Dropping malformed private-event payload", it) }
+            .getOrNull()
+
+    /** Extracts the error message, logging and dropping the payload (returns null) when malformed. */
+    internal fun parseErrorMessageOrNull(payload: String): String? =
+        runCatching { JSONObject(payload).optString("message", "An error occurred.") }
+            .onFailure { Log.w(tag, "Dropping malformed error payload", it) }
+            .getOrNull()
 
     /** Fetches the latest game state snapshot over REST. */
     suspend fun fetchGameState(gameId: String, playerId: String): GameState {
@@ -98,12 +116,17 @@ class GameRepository(
                 check(response.isSuccessful) { "Game state fetch failed: ${response.code}" }
                 val body = response.body!!.string()
                 Log.d(tag, "REST response gameId=$gameId code=${response.code} body=$body")
-                GameState.fromBackendJson(JSONObject(body)).also { state ->
-                    Log.d(
-                        tag,
-                        "REST parsed gameId=$gameId currentPlayerId=${state.currentTurnPlayerId} turnCount=${state.turnCount} status=${state.status}"
-                    )
-                }
+                runCatching { GameState.fromBackendJson(JSONObject(body)) }
+                    .getOrElse { error ->
+                        Log.w(tag, "Malformed REST game-state body gameId=$gameId", error)
+                        throw IllegalStateException("Malformed game-state response for game $gameId", error)
+                    }
+                    .also { state ->
+                        Log.d(
+                            tag,
+                            "REST parsed gameId=$gameId currentPlayerId=${state.currentTurnPlayerId} turnCount=${state.turnCount} status=${state.status}"
+                        )
+                    }
             }
         }
     }
@@ -123,7 +146,10 @@ class GameRepository(
             httpClient.newCall(request).execute().use { response ->
                 if (response.code == 404) return@withContext null
                 check(response.isSuccessful) { "Game state fetch failed: ${response.code}" }
-                GameState.fromBackendJson(JSONObject(response.body!!.string()))
+                val body = response.body!!.string()
+                runCatching { GameState.fromBackendJson(JSONObject(body)) }
+                    .onFailure { Log.w(tag, "Dropping malformed REST game-state body gameId=$gameId", it) }
+                    .getOrNull()
             }
         }
     }

--- a/app/src/test/java/com/doomhamsters/GameRepositoryTest.kt
+++ b/app/src/test/java/com/doomhamsters/GameRepositoryTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.test.runTest
 import org.hildan.krossbow.stomp.StompClient
 import org.hildan.krossbow.stomp.StompSession
 import org.json.JSONObject
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -77,5 +78,34 @@ class GameRepositoryTest {
         assertThrows<IllegalStateException> {
             repository.sendAction("GAME-1", "draw", payload)
         }
+    }
+
+    @Test
+    fun `parseErrorMessageOrNull returns message for valid payload`() {
+        val message = repository.parseErrorMessageOrNull("{\"message\":\"Not your turn\"}")
+
+        assertEquals("Not your turn", message)
+    }
+
+    @Test
+    fun `parseErrorMessageOrNull drops malformed payload`() {
+        assertNull(repository.parseErrorMessageOrNull("not json"))
+    }
+
+    @Test
+    fun `parsePrivateEventOrNull parses valid payload`() {
+        val event = repository.parsePrivateEventOrNull("{\"type\":\"DOOM_DRAWN\"}")
+
+        assertEquals("DOOM_DRAWN", event?.optString("type"))
+    }
+
+    @Test
+    fun `parsePrivateEventOrNull drops malformed payload`() {
+        assertNull(repository.parsePrivateEventOrNull("{not valid"))
+    }
+
+    @Test
+    fun `parseGameStateOrNull drops malformed payload`() {
+        assertNull(repository.parseGameStateOrNull("garbage"))
     }
 }


### PR DESCRIPTION
Makes GameRepository fail safe on malformed or unexpected payloads — they get logged at WARN and dropped instead of crashing the screen. Valid payloads behave as before.

* subscribeToGameState, subscribeToPrivateEvents and subscribeToErrors now drop a malformed payload (WARN + skip) and keep the flow alive — before, one bad message tore down the whole subscription and forced a reconnect
* fetchGameStateOrNull returns null on a malformed REST body, fetchGameState logs at WARN and rethrows a clear error instead of a raw JSONException
* Tests cover both the valid and the malformed-drop path

Closes #143