### PR TITLE
Refactor StartAndRulesScreen

### DIFF
--- a/app/src/main/java/com/doomhamsters/ui/lobby/StartAndRulesScreen.kt
+++ b/app/src/main/java/com/doomhamsters/ui/lobby/StartAndRulesScreen.kt
@@ -8,7 +8,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Surface
@@ -17,20 +19,21 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.doomhamsters.LobbyViewModel
 import com.doomhamsters.R
-import com.doomhamsters.ui.theme.DarkBrown
+import com.doomhamsters.ui.theme.AccentOrange
+import com.doomhamsters.ui.theme.BackgroundCream
+import com.doomhamsters.ui.theme.CardDarkMaroon
 import com.doomhamsters.ui.theme.DoomHamstersTheme
-import com.doomhamsters.ui.theme.Orange
 import com.doomhamsters.ui.theme.SoftWhite
-import com.doomhamsters.ui.theme.WarmAlmond
 
 /** Displays the app welcome screen and entry actions. */
 @Composable
@@ -41,7 +44,7 @@ fun StartScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .background(WarmAlmond)
+            .background(CardDarkMaroon)
             .padding(24.dp),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
@@ -54,7 +57,7 @@ fun StartScreen(
             lineHeight = 20.sp,
             fontSize = 32.sp,
             fontWeight = FontWeight.Bold,
-            color = Orange
+            color = AccentOrange
         )
 
         Spacer(modifier = Modifier.weight(1f))
@@ -66,7 +69,7 @@ fun StartScreen(
                 .height(56.dp),
             shape = RoundedCornerShape(50),
             colors = ButtonDefaults.buttonColors(
-                containerColor = Orange,
+                containerColor = AccentOrange,
                 contentColor = SoftWhite
             ),
             elevation = ButtonDefaults.buttonElevation(defaultElevation = 3.dp)
@@ -88,7 +91,7 @@ fun StartScreen(
                 .height(56.dp),
             shape = RoundedCornerShape(50),
             colors = ButtonDefaults.buttonColors(
-                containerColor = Orange,
+                containerColor = AccentOrange,
                 contentColor = SoftWhite
             ),
             elevation = ButtonDefaults.buttonElevation(defaultElevation = 3.dp)
@@ -109,7 +112,7 @@ fun RulesScreen(modifier: Modifier = Modifier, onBackClick: () -> Unit) {
     Column(
         modifier = modifier
             .fillMaxSize()
-            .background(WarmAlmond)
+            .background(CardDarkMaroon)
             .padding(24.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
@@ -117,30 +120,34 @@ fun RulesScreen(modifier: Modifier = Modifier, onBackClick: () -> Unit) {
             text = stringResource(R.string.rules_title),
             fontSize = 32.sp,
             fontWeight = FontWeight.Bold,
-            color = Orange
+            color = AccentOrange
         )
 
         Spacer(modifier = Modifier.height(24.dp))
 
         Surface(
             shape = RoundedCornerShape(16.dp),
-            color = Color.White.copy(alpha = 0.5f),
+            color = BackgroundCream,
             modifier = Modifier
                 .fillMaxWidth()
+                .weight(1f)
                 .shadow(elevation = 1.dp, shape = RoundedCornerShape(16.dp))
         ) {
             Column(
-                modifier = Modifier.padding(16.dp)
+                modifier = Modifier
+                    .padding(16.dp)
+                    .verticalScroll(rememberScrollState())
             ) {
                 Text(
-                    text = stringResource(R.string.rules_content),
+                    text = AnnotatedString.fromHtml(stringResource(R.string.rules_content)),
                     fontSize = 18.sp,
-                    color = DarkBrown
+                    lineHeight = 24.sp,
+                    color = CardDarkMaroon
                 )
             }
         }
 
-        Spacer(modifier = Modifier.weight(1f))
+        Spacer(modifier = Modifier.height(16.dp))
 
         Button(
             onClick = onBackClick,
@@ -149,8 +156,8 @@ fun RulesScreen(modifier: Modifier = Modifier, onBackClick: () -> Unit) {
                 .height(56.dp),
             shape = RoundedCornerShape(50),
             colors = ButtonDefaults.buttonColors(
-                containerColor = Orange,
-                contentColor = Color.White
+                containerColor = AccentOrange,
+                contentColor = SoftWhite
             ),
             elevation = ButtonDefaults.buttonElevation(defaultElevation = 3.dp)
         ) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,11 +1,30 @@
 <resources>
     <string name="app_name">DoomHamsters</string>
     <string name="title_activity_rules">RulesActivity</string>
-    <string name="rules_title">Spielregeln</string>
-    <string name="rules_content">Hier werden die Spielregeln stehen:\n\n 1. ... \n\n 2. ... \n\n 3. ...</string>
-    <string name="rules_back">Zurück zur Lobby</string>
-    <string name="welcome_message">Willkommen bei\n\nDoom Hamsters!</string>
-    <string name="rules_button_text">Spielregeln ansehen</string>
-    <string name="start_button_text">Spiel starten</string>
-    <string name="leave_lobby_text">LOBBY VERLASSEN</string>
+    <string name="rules_title">Rules</string>
+    <string name="rules_content">&lt;b&gt;Goal&lt;/b&gt;&lt;br&gt;Be the last hamster standing.&lt;br&gt;&lt;br&gt;
+&lt;b&gt;Your turn&lt;/b&gt;&lt;br&gt;Play any action cards you like, then end your turn by drawing one card from the deck.&lt;br&gt;&lt;br&gt;
+&lt;b&gt;Doom&lt;/b&gt;&lt;br&gt;Draw a Doom card and you lose a life. A Snack Stash saves you. Lose all your lives and you\'re out.&lt;br&gt;&lt;br&gt;
+&lt;b&gt;Cheating &#8211; the Snack Stash bluff&lt;/b&gt;&lt;br&gt;When you face a Doom you can play a real Snack Stash, or bluff by claiming one you don\'t have. The other players then vote Accept or Challenge:&lt;br&gt;
+&#8226; Nobody challenges &#8211; your claim stands and you survive.&lt;br&gt;
+&#8226; Challenged while bluffing &#8211; you\'re caught and take the Doom.&lt;br&gt;
+&#8226; Challenged but you really had it &#8211; the challenger was wrong and pays for it.&lt;br&gt;&lt;br&gt;
+&lt;b&gt;Cards&lt;/b&gt;&lt;br&gt;
+&#8226; &lt;i&gt;Snack Stash&lt;/i&gt; &#8211; Saves you from one Doom.&lt;br&gt;
+&#8226; &lt;i&gt;Sign of Fate&lt;/i&gt; &#8211; Gain 1 life.&lt;br&gt;
+&#8226; &lt;i&gt;Power Nap&lt;/i&gt; &#8211; Skip drawing and end your turn.&lt;br&gt;
+&#8226; &lt;i&gt;Quick Peek&lt;/i&gt; &#8211; Privately see the top card.&lt;br&gt;
+&#8226; &lt;i&gt;Sniff Ahead&lt;/i&gt; &#8211; Secretly see the top 3 cards.&lt;br&gt;
+&#8226; &lt;i&gt;Tunnel Chaos&lt;/i&gt; &#8211; Shuffle the deck.&lt;br&gt;
+&#8226; &lt;i&gt;Tiny Thief&lt;/i&gt; &#8211; Steal a random card from a player.&lt;br&gt;
+&#8226; &lt;i&gt;Beg for Snacks&lt;/i&gt; &#8211; Name a card and a player; if they have it, they hand it over.&lt;br&gt;
+&#8226; &lt;i&gt;Cage Swap&lt;/i&gt; &#8211; Swap hands with the next player.&lt;br&gt;
+&#8226; &lt;i&gt;Hyper Mode&lt;/i&gt; &#8211; The next player takes an extra turn.&lt;br&gt;
+&#8226; &lt;i&gt;Squick&lt;/i&gt; &#8211; Cancel the last played card.&lt;br&gt;
+&#8226; &lt;i&gt;Hamster Combos&lt;/i&gt; &#8211; Play 2 to steal a random card, 3 to take a named card, 4 to steal a life.</string>
+    <string name="rules_back">Back to Lobby</string>
+    <string name="welcome_message">Welcome to\n\nDoom Hamsters!</string>
+    <string name="rules_button_text">View Rules</string>
+    <string name="start_button_text">Start Game</string>
+    <string name="leave_lobby_text">LEAVE LOBBY</string>
 </resources>


### PR DESCRIPTION
The start and rules screen was still in German, used the old lobby colors and the rules were just placeholders. This reworks it so it fits the rest of the game.

What changed:
- all texts translated to English
- colors switched to the game palette so it matches the gameboard
- added the real rules including the Snack Stash cheat mechanic, with bold headers and italic card names
- rules panel is scrollable now so longer text doesn't get cut off