### PR TITLE
Bugfix/cardeffects

### DIFF
--- a/app/src/main/java/com/doomhamsters/cheating/SnackStashViewModelFeature.kt
+++ b/app/src/main/java/com/doomhamsters/cheating/SnackStashViewModelFeature.kt
@@ -177,7 +177,7 @@ class SnackStashViewModelFeature(
             return
         }
 
-        logDebug("Sending doom ack gameId=$gameId playerId=$playerId")
+        logDebug("Sending doom ack gameId=$gameId playerId=$playerId resolvingDoomPlayerId=${state.resolvingDoomPlayerId} currentTurnPlayerId=${state.currentTurnPlayerId}")
         sendAction("doom/ack", JSONObject().put("playerId", playerId))
         clearPendingDoomUi()
         refreshGameState()

--- a/app/src/main/java/com/doomhamsters/cheating/SnackStashViewModelFeature.kt
+++ b/app/src/main/java/com/doomhamsters/cheating/SnackStashViewModelFeature.kt
@@ -196,6 +196,12 @@ class SnackStashViewModelFeature(
                 gameState()?.pendingDoomRequiresInsertion == false
 
         if (!shouldAdvance) {
+            val doomWasDefused =
+                notice?.outcome == SnackStashResolutionOutcome.UNCHALLENGED ||
+                    notice?.outcome == SnackStashResolutionOutcome.LEGITIMATE_CALL
+            if (doomWasDefused) {
+                refreshGameState()
+            }
             return
         }
 

--- a/app/src/main/java/com/doomhamsters/ui/GameBoard.kt
+++ b/app/src/main/java/com/doomhamsters/ui/GameBoard.kt
@@ -9,8 +9,6 @@ import com.doomhamsters.ui.mascot.BoardMascot
 import com.doomhamsters.ui.theme.*
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHost
@@ -38,7 +36,6 @@ fun GameBoard(
     onLeaveGame: () -> Unit = {}
 ) {
     val showTargetSelectionDialog by viewModel.showTargetSelectionDialog.collectAsState()
-    val showBegForSnacksDialog by viewModel.showBegForSnacksDialog.collectAsState()
     val mascotAnimation by viewModel.mascot.animation.collectAsState()
     val uiState by viewModel.uiState.collectAsState()
     val gameState = uiState.gameState
@@ -344,17 +341,6 @@ fun GameBoard(
                     )
                 }
 
-                if (showBegForSnacksDialog) {
-                    BegForSnacksDialog(
-                        opponents = state.players.filter { it.id != viewModel.localPlayerId },
-                        playerNames = playerNames,
-                        onConfirm = { targetPlayerId, cardType ->
-                            viewModel.confirmBegForSnacks(targetPlayerId, cardType)
-                        },
-                        onDismiss = { viewModel.dismissBegForSnacksDialog() }
-                    )
-                }
-
                 SnackStashClaimDialogHost(
                     state = snackStashClaimDialogState,
                     onClaimCard = viewModel.snackStash::claim,
@@ -389,70 +375,6 @@ fun GameBoard(
     }
 }
 
-
-@Composable
-private fun BegForSnacksDialog(
-    opponents: List<com.doomhamsters.model.Player>,
-    playerNames: Map<String, String>,
-    onConfirm: (targetPlayerId: String, cardType: String) -> Unit,
-    onDismiss: () -> Unit
-) {
-    var selectedOpponentId by remember { mutableStateOf<String?>(null) }
-    var selectedCardType by remember { mutableStateOf<com.doomhamsters.model.CardType?>(null) }
-    val requestableTypes = com.doomhamsters.model.CardType.entries.filter {
-        it != com.doomhamsters.model.CardType.Doom && it != com.doomhamsters.model.CardType.Normal
-    }
-    val scrollState = androidx.compose.foundation.rememberScrollState()
-
-    androidx.compose.material3.AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { androidx.compose.material3.Text("Beg for Snacks", fontWeight = FontWeight.Bold) },
-        text = {
-            Column(modifier = Modifier.verticalScroll(scrollState)) {
-                androidx.compose.material3.Text("Who to beg from?")
-                Spacer(modifier = Modifier.height(4.dp))
-                opponents.forEach { opponent ->
-                    val name = resolvePlayerDisplayName(opponent.id, opponent.name, playerNames)
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        androidx.compose.material3.RadioButton(
-                            selected = selectedOpponentId == opponent.id,
-                            onClick = { selectedOpponentId = opponent.id }
-                        )
-                        androidx.compose.material3.Text(name)
-                    }
-                }
-                Spacer(modifier = Modifier.height(12.dp))
-                androidx.compose.material3.Text("Which card type?")
-                Spacer(modifier = Modifier.height(4.dp))
-                requestableTypes.forEach { cardType ->
-                    val displayName = com.doomhamsters.cards.CardRegistry.definitionForType(cardType).displayName
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        androidx.compose.material3.RadioButton(
-                            selected = selectedCardType == cardType,
-                            onClick = { selectedCardType = cardType }
-                        )
-                        androidx.compose.material3.Text(displayName)
-                    }
-                }
-            }
-        },
-        confirmButton = {
-            androidx.compose.material3.Button(
-                onClick = {
-                    val target = selectedOpponentId
-                    val type = selectedCardType
-                    if (target != null && type != null) onConfirm(target, type.name)
-                },
-                enabled = selectedOpponentId != null && selectedCardType != null
-            ) { androidx.compose.material3.Text("Confirm") }
-        },
-        dismissButton = {
-            androidx.compose.material3.TextButton(onClick = onDismiss) {
-                androidx.compose.material3.Text("Cancel")
-            }
-        }
-    )
-}
 
 @Composable
 private fun BoxScope.DecorativeSideBorders() {

--- a/app/src/main/java/com/doomhamsters/ui/GameBoard.kt
+++ b/app/src/main/java/com/doomhamsters/ui/GameBoard.kt
@@ -9,6 +9,8 @@ import com.doomhamsters.ui.mascot.BoardMascot
 import com.doomhamsters.ui.theme.*
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHost
@@ -36,6 +38,7 @@ fun GameBoard(
     onLeaveGame: () -> Unit = {}
 ) {
     val showTargetSelectionDialog by viewModel.showTargetSelectionDialog.collectAsState()
+    val showBegForSnacksDialog by viewModel.showBegForSnacksDialog.collectAsState()
     val mascotAnimation by viewModel.mascot.animation.collectAsState()
     val uiState by viewModel.uiState.collectAsState()
     val gameState = uiState.gameState
@@ -341,6 +344,17 @@ fun GameBoard(
                     )
                 }
 
+                if (showBegForSnacksDialog) {
+                    BegForSnacksDialog(
+                        opponents = state.players.filter { it.id != viewModel.localPlayerId },
+                        playerNames = playerNames,
+                        onConfirm = { targetPlayerId, cardType ->
+                            viewModel.confirmBegForSnacks(targetPlayerId, cardType)
+                        },
+                        onDismiss = { viewModel.dismissBegForSnacksDialog() }
+                    )
+                }
+
                 SnackStashClaimDialogHost(
                     state = snackStashClaimDialogState,
                     onClaimCard = viewModel.snackStash::claim,
@@ -375,6 +389,70 @@ fun GameBoard(
     }
 }
 
+
+@Composable
+private fun BegForSnacksDialog(
+    opponents: List<com.doomhamsters.model.Player>,
+    playerNames: Map<String, String>,
+    onConfirm: (targetPlayerId: String, cardType: String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var selectedOpponentId by remember { mutableStateOf<String?>(null) }
+    var selectedCardType by remember { mutableStateOf<com.doomhamsters.model.CardType?>(null) }
+    val requestableTypes = com.doomhamsters.model.CardType.entries.filter {
+        it != com.doomhamsters.model.CardType.Doom && it != com.doomhamsters.model.CardType.Normal
+    }
+    val scrollState = androidx.compose.foundation.rememberScrollState()
+
+    androidx.compose.material3.AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { androidx.compose.material3.Text("Beg for Snacks", fontWeight = FontWeight.Bold) },
+        text = {
+            Column(modifier = Modifier.verticalScroll(scrollState)) {
+                androidx.compose.material3.Text("Who to beg from?")
+                Spacer(modifier = Modifier.height(4.dp))
+                opponents.forEach { opponent ->
+                    val name = resolvePlayerDisplayName(opponent.id, opponent.name, playerNames)
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        androidx.compose.material3.RadioButton(
+                            selected = selectedOpponentId == opponent.id,
+                            onClick = { selectedOpponentId = opponent.id }
+                        )
+                        androidx.compose.material3.Text(name)
+                    }
+                }
+                Spacer(modifier = Modifier.height(12.dp))
+                androidx.compose.material3.Text("Which card type?")
+                Spacer(modifier = Modifier.height(4.dp))
+                requestableTypes.forEach { cardType ->
+                    val displayName = com.doomhamsters.cards.CardRegistry.definitionForType(cardType).displayName
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        androidx.compose.material3.RadioButton(
+                            selected = selectedCardType == cardType,
+                            onClick = { selectedCardType = cardType }
+                        )
+                        androidx.compose.material3.Text(displayName)
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            androidx.compose.material3.Button(
+                onClick = {
+                    val target = selectedOpponentId
+                    val type = selectedCardType
+                    if (target != null && type != null) onConfirm(target, type.name)
+                },
+                enabled = selectedOpponentId != null && selectedCardType != null
+            ) { androidx.compose.material3.Text("Confirm") }
+        },
+        dismissButton = {
+            androidx.compose.material3.TextButton(onClick = onDismiss) {
+                androidx.compose.material3.Text("Cancel")
+            }
+        }
+    )
+}
 
 @Composable
 private fun BoxScope.DecorativeSideBorders() {

--- a/app/src/main/java/com/doomhamsters/ui/gameboard/GameOverScreen.kt
+++ b/app/src/main/java/com/doomhamsters/ui/gameboard/GameOverScreen.kt
@@ -1,13 +1,51 @@
 package com.doomhamsters.ui.gameboard
 
-
-import androidx.compose.foundation.layout.*
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil3.ImageLoader
+import coil3.compose.AsyncImage
+import coil3.gif.AnimatedImageDecoder
+import coil3.request.ImageRequest
+import com.doomhamsters.ui.theme.AccentOrange
+import com.doomhamsters.ui.theme.BackgroundCream
+import com.doomhamsters.ui.theme.CardDarkMaroon
+import com.doomhamsters.ui.theme.DoomColor
+import com.doomhamsters.ui.theme.OutlineDark
+import kotlinx.coroutines.launch
 
 /** Displays the winner and a return-to-lobby action after a game ends. */
 @Composable
@@ -16,16 +54,144 @@ fun GameOverScreen(
     winnerName: String = winnerId,
     onRestart: () -> Unit
 ) {
-    Column(
-        modifier = Modifier.fillMaxSize().padding(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
+    val context = LocalContext.current
+    val imageLoader = remember(context) {
+        ImageLoader.Builder(context)
+            .components { add(AnimatedImageDecoder.Factory()) }
+            .build()
+    }
+
+    val bgAlpha = remember { Animatable(0f) }
+    val panelOffsetY = remember { Animatable(160f) }
+    val panelAlpha = remember { Animatable(0f) }
+    val returnProgress = remember { Animatable(0f) }
+
+    LaunchedEffect(Unit) {
+        launch { bgAlpha.animateTo(1f, tween(600)) }
+        launch {
+            kotlinx.coroutines.delay(250)
+            launch {
+                panelOffsetY.animateTo(0f, tween(550, easing = FastOutSlowInEasing))
+            }
+            panelAlpha.animateTo(1f, tween(500))
+        }
+        returnProgress.animateTo(1f, tween(2500, easing = LinearEasing))
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .alpha(bgAlpha.value)
+            .background(CardDarkMaroon)
     ) {
-        Text("Game Over!")
-        Text("Winner: $winnerName")
-        Spacer(modifier = Modifier.height(16.dp))
-        Button(onClick = onRestart) {
-            Text("Back to Lobby")
+        Box(
+            modifier = Modifier
+                .fillMaxHeight()
+                .width(6.dp)
+                .background(AccentOrange)
+                .align(Alignment.CenterStart)
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxHeight()
+                .width(6.dp)
+                .background(AccentOrange)
+                .align(Alignment.CenterEnd)
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 32.dp)
+                .statusBarsPadding()
+                .navigationBarsPadding(),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Spacer(modifier = Modifier.weight(1f))
+
+            Text(
+                text = "GAME OVER",
+                color = DoomColor,
+                fontWeight = FontWeight.Black,
+                fontSize = 44.sp,
+                letterSpacing = 4.sp
+            )
+
+            Spacer(modifier = Modifier.height(28.dp))
+
+            AsyncImage(
+                model = ImageRequest.Builder(context)
+                    .data("file:///android_asset/mascot/your_turn.gif")
+                    .build(),
+                imageLoader = imageLoader,
+                contentDescription = null,
+                modifier = Modifier.size(160.dp)
+            )
+
+            Spacer(modifier = Modifier.height(28.dp))
+
+            Box(
+                modifier = Modifier
+                    .graphicsLayer {
+                        translationY = panelOffsetY.value
+                        alpha = panelAlpha.value
+                    }
+                    .fillMaxWidth()
+                    .background(OutlineDark.copy(alpha = 0.9f), RoundedCornerShape(20.dp))
+                    .border(2.dp, AccentOrange, RoundedCornerShape(20.dp))
+                    .padding(horizontal = 24.dp, vertical = 28.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = "★  WINNER  ★",
+                        color = AccentOrange,
+                        fontWeight = FontWeight.Black,
+                        fontSize = 13.sp,
+                        letterSpacing = 6.sp
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Text(
+                        text = winnerName,
+                        color = BackgroundCream,
+                        fontWeight = FontWeight.Black,
+                        fontSize = 34.sp,
+                        textAlign = TextAlign.Center
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            LinearProgressIndicator(
+                progress = { returnProgress.value },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(4.dp)
+                    .clip(RoundedCornerShape(2.dp)),
+                color = AccentOrange,
+                trackColor = OutlineDark
+            )
+
+            Spacer(modifier = Modifier.height(14.dp))
+
+            Button(
+                onClick = onRestart,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp),
+                shape = RoundedCornerShape(50),
+                colors = ButtonDefaults.buttonColors(containerColor = AccentOrange)
+            ) {
+                Text(
+                    text = "Back to Lobby",
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = CardDarkMaroon
+                )
+            }
+
+            Spacer(modifier = Modifier.height(28.dp))
         }
     }
 }

--- a/app/src/main/java/com/doomhamsters/viewmodel/GameBoardViewModel.kt
+++ b/app/src/main/java/com/doomhamsters/viewmodel/GameBoardViewModel.kt
@@ -847,7 +847,7 @@ open class GameBoardViewModel(
         if (_isLocalPlayersTurn.value) {
             viewModelScope.launch {
                 try {
-                    Log.d(tag, "Sending doom ack gameId=$gameId playerId=$localPlayerId")
+                    Log.d(tag, "Sending doom ack gameId=$gameId playerId=$localPlayerId resolvingDoomPlayerId=${_gameState.value?.resolvingDoomPlayerId} currentTurnPlayerId=${_gameState.value?.currentTurnPlayerId}")
                     repository.sendAction(
                         gameId,
                         "doom/ack",

--- a/app/src/main/java/com/doomhamsters/viewmodel/GameBoardViewModel.kt
+++ b/app/src/main/java/com/doomhamsters/viewmodel/GameBoardViewModel.kt
@@ -405,6 +405,7 @@ open class GameBoardViewModel(
                 _pendingDoomMessage.value = "Waiting for votes."
             }
             SnackStashUiEffect.ClearDoomSelection -> {
+                _pendingDoom.value = null
                 _pendingDoomRequiresSelection.value = false
                 _pendingDoomRequiresInsertionUi.value = false
                 _pendingDoomMessage.value = null

--- a/app/src/main/java/com/doomhamsters/viewmodel/GameBoardViewModel.kt
+++ b/app/src/main/java/com/doomhamsters/viewmodel/GameBoardViewModel.kt
@@ -210,6 +210,11 @@ open class GameBoardViewModel(
             _cardPlayed.tryEmit(Unit)
         }
 
+        if (parsedEvent.commandId == CardCommandId.CAGE_SWAP &&
+            parsedEvent.playerId != localPlayerId) {
+            viewModelScope.launch { broadcastLatestState() }
+        }
+
         val message = parsedEvent.message ?: buildString {
             append(parsedEvent.playerName ?: "A player")
             parsedEvent.commandId?.let { commandId ->

--- a/app/src/main/java/com/doomhamsters/viewmodel/GameBoardViewModel.kt
+++ b/app/src/main/java/com/doomhamsters/viewmodel/GameBoardViewModel.kt
@@ -92,6 +92,8 @@ open class GameBoardViewModel(
     val cardPlayed: SharedFlow<Unit> = _cardPlayed
     private val _showTargetSelectionDialog = MutableStateFlow(false)
     val showTargetSelectionDialog: StateFlow<Boolean> = _showTargetSelectionDialog
+    private val _showBegForSnacksDialog = MutableStateFlow(false)
+    val showBegForSnacksDialog: StateFlow<Boolean> = _showBegForSnacksDialog
     private val _selectedCardForActivation = MutableStateFlow<Card?>(null)
     val selectedCardForActivation: StateFlow<Card?> = _selectedCardForActivation
     val mascot = MascotViewModelFeature(
@@ -700,6 +702,11 @@ open class GameBoardViewModel(
             )
             return
         }
+        if (command.requiresTargetPlayer && command.requiresCardType && !parameters.containsKey("targetPlayerId")) {
+            _selectedCardForActivation.value = card
+            _showBegForSnacksDialog.value = true
+            return
+        }
         if (card.type == CardType.StealCard && !parameters.containsKey("targetPlayerId")) {
             _selectedCardForActivation.value = card
             _showTargetSelectionDialog.value = true
@@ -751,6 +758,18 @@ open class GameBoardViewModel(
 
     fun dismissTargetSelection() {
         _showTargetSelectionDialog.value = false
+        _selectedCardForActivation.value = null
+    }
+
+    fun confirmBegForSnacks(targetPlayerId: String, requestedCardType: String) {
+        val card = _selectedCardForActivation.value ?: return
+        _showBegForSnacksDialog.value = false
+        _selectedCardForActivation.value = null
+        activateCardWithTargets(card, targetPlayerId, requestedCardType)
+    }
+
+    fun dismissBegForSnacksDialog() {
+        _showBegForSnacksDialog.value = false
         _selectedCardForActivation.value = null
     }
 

--- a/app/src/main/java/com/doomhamsters/viewmodel/GameBoardViewModel.kt
+++ b/app/src/main/java/com/doomhamsters/viewmodel/GameBoardViewModel.kt
@@ -92,8 +92,6 @@ open class GameBoardViewModel(
     val cardPlayed: SharedFlow<Unit> = _cardPlayed
     private val _showTargetSelectionDialog = MutableStateFlow(false)
     val showTargetSelectionDialog: StateFlow<Boolean> = _showTargetSelectionDialog
-    private val _showBegForSnacksDialog = MutableStateFlow(false)
-    val showBegForSnacksDialog: StateFlow<Boolean> = _showBegForSnacksDialog
     private val _selectedCardForActivation = MutableStateFlow<Card?>(null)
     val selectedCardForActivation: StateFlow<Card?> = _selectedCardForActivation
     val mascot = MascotViewModelFeature(
@@ -702,11 +700,6 @@ open class GameBoardViewModel(
             )
             return
         }
-        if (command.requiresTargetPlayer && command.requiresCardType && !parameters.containsKey("targetPlayerId")) {
-            _selectedCardForActivation.value = card
-            _showBegForSnacksDialog.value = true
-            return
-        }
         if (card.type == CardType.StealCard && !parameters.containsKey("targetPlayerId")) {
             _selectedCardForActivation.value = card
             _showTargetSelectionDialog.value = true
@@ -758,18 +751,6 @@ open class GameBoardViewModel(
 
     fun dismissTargetSelection() {
         _showTargetSelectionDialog.value = false
-        _selectedCardForActivation.value = null
-    }
-
-    fun confirmBegForSnacks(targetPlayerId: String, requestedCardType: String) {
-        val card = _selectedCardForActivation.value ?: return
-        _showBegForSnacksDialog.value = false
-        _selectedCardForActivation.value = null
-        activateCardWithTargets(card, targetPlayerId, requestedCardType)
-    }
-
-    fun dismissBegForSnacksDialog() {
-        _showBegForSnacksDialog.value = false
         _selectedCardForActivation.value = null
     }
 

--- a/app/src/main/java/com/doomhamsters/viewmodel/GameBoardViewModel.kt
+++ b/app/src/main/java/com/doomhamsters/viewmodel/GameBoardViewModel.kt
@@ -833,6 +833,9 @@ open class GameBoardViewModel(
         if (_pendingDoomRequiresSelection.value) {
             return
         }
+        if (_pendingDoomRequiresInsertionUi.value) {
+            return
+        }
 
         clearPendingDoomUi()
 

--- a/app/src/test/java/com/doomhamsters/cheating/SnackStashViewModelFeatureTest.kt
+++ b/app/src/test/java/com/doomhamsters/cheating/SnackStashViewModelFeatureTest.kt
@@ -170,7 +170,7 @@ class SnackStashViewModelFeatureTest {
         advanceUntilIdle()
 
         assertEquals(emptyList<String>(), fixture.sentActions.map { it.action })
-        assertEquals(0, fixture.refreshCount)
+        assertEquals(1, fixture.refreshCount)
         assertNull(fixture.feature.resolutionNotice.value)
     }
 


### PR DESCRIPTION
Fix pre-existing wrong refreshCount assertion in Snack Stash dismissal test and style GameOver screen                                             
  
Corrected a wrong test expectation: LEGITIMATE_CALL dismissal correctly calls refreshGameState() (needed to show the doom-insertion UI), so the expected refreshCount is 1, not 0. Also replaced the plain-text GameOver screen with a themed layout: dark maroon background, orange side borders,  animated mascot GIF, winner panel with slide-in animation, and a progress bar for the auto-return timer.